### PR TITLE
fix GameManger.cs

### DIFF
--- a/Assets/_Project/Resources/UI/PopupResult.prefab
+++ b/Assets/_Project/Resources/UI/PopupResult.prefab
@@ -35,9 +35,84 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 320, y: -231}
+  m_AnchoredPosition: {x: 510, y: -231}
   m_SizeDelta: {x: 300, y: 450}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1169413998550787615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1212517209596258851}
+  - component: {fileID: 2182234299486886528}
+  - component: {fileID: 38208723134940640}
+  m_Layer: 5
+  m_Name: character
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1212517209596258851
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169413998550787615}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8855997948328607867}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -130}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &2182234299486886528
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169413998550787615}
+  m_CullTransparentMesh: 1
+--- !u!114 &38208723134940640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169413998550787615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: aa22fa5d05b76504ab977027c60fc787, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1677809348446381624
 GameObject:
   m_ObjectHideFlags: 0
@@ -223,7 +298,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -231}
+  m_AnchoredPosition: {x: 810, y: -231}
   m_SizeDelta: {x: 300, y: 450}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2199838267439471292
@@ -333,6 +408,7 @@ RectTransform:
   - {fileID: 5023560749446176784}
   - {fileID: 8381319602236346648}
   - {fileID: 5839444938857538446}
+  - {fileID: 8855997948328607867}
   m_Father: {fileID: 7432265523577787406}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -359,8 +435,8 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 4
   m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
@@ -921,6 +997,180 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &4720776033735409824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5131231549403479659}
+  - component: {fileID: 4548766665603911530}
+  - component: {fileID: 8968492766188932772}
+  m_Layer: 5
+  m_Name: nickname
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5131231549403479659
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4720776033735409824}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8855997948328607867}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 192}
+  m_SizeDelta: {x: 300, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4548766665603911530
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4720776033735409824}
+  m_CullTransparentMesh: 1
+--- !u!114 &8968492766188932772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4720776033735409824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC2AC\uAE30\uB85C\uC6B4 \uD53C\uCE74\uCE04"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 54767ba5fd4c65d4fbbc1d2abb1c8b7f, type: 2}
+  m_sharedMaterial: {fileID: 1575574767915447597, guid: 54767ba5fd4c65d4fbbc1d2abb1c8b7f, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5477822317384228613
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8855997948328607867}
+  m_Layer: 5
+  m_Name: winnerSlot (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8855997948328607867
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5477822317384228613}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8374076166289212354}
+  - {fileID: 1212517209596258851}
+  - {fileID: 5131231549403479659}
+  m_Father: {fileID: 3581564696938250754}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1410, y: -231}
+  m_SizeDelta: {x: 300, y: 450}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5787016966814503378
 GameObject:
   m_ObjectHideFlags: 0
@@ -956,7 +1206,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1600, y: -231}
+  m_AnchoredPosition: {x: 1110, y: -231}
   m_SizeDelta: {x: 300, y: 450}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5894103675659631624
@@ -1105,6 +1355,81 @@ MonoBehaviour:
   role: {fileID: 191203210077953201}
   roleText: {fileID: 1921525212387568042}
   exit: {fileID: 4719350543446385599}
+--- !u!1 &7225425031336409778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8374076166289212354}
+  - component: {fileID: 529995528656586323}
+  - component: {fileID: 6045858741617772563}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8374076166289212354
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7225425031336409778}
+  m_LocalRotation: {x: 0.45453468, y: 0, z: 0, w: 0.89072907}
+  m_LocalPosition: {x: 0, y: 0, z: -177}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8855997948328607867}
+  m_LocalEulerAnglesHint: {x: 54.07, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -122}
+  m_SizeDelta: {x: 250, y: 250}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &529995528656586323
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7225425031336409778}
+  m_CullTransparentMesh: 1
+--- !u!114 &6045858741617772563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7225425031336409778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 96d4d4384de924045abe5d240e8b191a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7259557741783303472
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Scripts/Manager/GameManager.cs
+++ b/Assets/_Project/Scripts/Manager/GameManager.cs
@@ -9,6 +9,7 @@ using System;
 using UnityEngine.TextCore.Text;
 using Unity.Cinemachine;
 using NavMeshPlus.Components;
+using System.Linq;
 
 public class GameManager : MonoSingleton<GameManager>
 {
@@ -45,7 +46,13 @@ public class GameManager : MonoSingleton<GameManager>
     private int day = 0;
     private bool isAfternoon = true;
     public bool isPlaying;
-
+    bool isBossRound = false;
+    int survivalDeathCount = 0;
+    public enum GameResult
+    {
+        SurvivorsWin,
+        BossWin
+    }
     public List<CardDataSO> pleaMarketCards = new List<CardDataSO>();
     List<Transform> spawns;
     public bool isSelectBombTarget = false;
@@ -129,32 +136,24 @@ public class GameManager : MonoSingleton<GameManager>
 
     public async void SetGameState(PhaseType PhaseType, long NextPhaseAt)
     {
+        Debug.Log("SetGameState: " + PhaseType);
         if (PhaseType == PhaseType.Day)
         {
             UserInfo.myInfo.OnDayOfAfter();
             day++;
         }
+        else if (PhaseType == PhaseType.Evening)
+        {
+            isBossRound = true;
+        }
 
         foreach (var key in characters.Keys)
         {
-            if (PhaseType == PhaseType.Day)
-                characters[key].OnChangeState<CharacterIdleState>();
-            else
-                characters[key].OnChangeState<CharacterStopState>();
+            characters[key].OnChangeState<CharacterIdleState>();
         }
 
         isAfternoon = PhaseType == PhaseType.Day;
         UIManager.Get<UIGame>().OnDaySetting(day, PhaseType, NextPhaseAt);
-
-        if (PhaseType == PhaseType.End)
-        {
-            if (UserInfo.myInfo.handCards.Count > UserInfo.myInfo.hp)
-                UIManager.Show<PopupRemoveCardSelection>();
-        }
-        else
-        {
-            UIManager.Hide<PopupRemoveCardSelection>();
-        }
 
         isPlaying = true;
         UIGame.instance.SetDeckCount();
@@ -579,6 +578,31 @@ public class GameManager : MonoSingleton<GameManager>
         return Vector3.Distance(userCharacter.transform.position, targetCharacter.transform.position) <= 4.5f;
     }
 
+    public void CheckBossRound(UserInfo userInfo)
+    {
+        Debug.Log("CheckBossRound: " + userInfo.roleType);
+        if (isBossRound)
+        {
+            if (userInfo.roleType == eRoleType.psychopass)
+            {
+                // 보스 캐릭터 사망 시 생존자 승리 (서버에서 처리해 줌)
+                //SetResult(GameResult.SurvivorsWin);
+            }
+            else if (userInfo.roleType == eRoleType.bodyguard)
+            {
+                // 생존자 모두 사망 시 보스 캐릭터 승리
+                survivalDeathCount++;
+                Debug.Log("survivalDeathCount: " + survivalDeathCount);
+                // 생존자 수를 계산
+                int survivorCount = DataManager.instance.users.Where(user => user.roleType == eRoleType.bodyguard).Count();
+                if (survivalDeathCount == survivorCount)
+                {
+                    SetResult(GameResult.BossWin);
+                }
+            }
+        }
+    }
+
     public void OnGameEnd()
     {
         isPlaying = false;
@@ -589,6 +613,24 @@ public class GameManager : MonoSingleton<GameManager>
     public void UnselectCard()
     {
         selectedCard = null;
+    }
+
+    public void SetResult(GameResult result)
+    {
+        GamePacket packet = new GamePacket();
+
+        // 결과에 따라 다른 ReactionType 설정
+        switch (result)
+        {
+            case GameResult.SurvivorsWin:
+                packet.ReactionRequest = new C2SReactionRequest() { ReactionType = ReactionType.NoneReaction };
+                break;
+            case GameResult.BossWin:
+                packet.ReactionRequest = new C2SReactionRequest() { ReactionType = ReactionType.NotUseCard };
+                break;
+        }
+
+        Managers.networkManager.GameServerSend(packet);
     }
 
 }

--- a/Assets/_Project/Scripts/WorldObjects/Character.cs
+++ b/Assets/_Project/Scripts/WorldObjects/Character.cs
@@ -298,7 +298,7 @@ public class Character : FSMController<CharacterState, CharacterFSM, CharacterDa
                 {
                     Debug.Log("OnTriggerExit2D: Leaved Store");
                     UIGame.instance.SetShopButton(false);
-                }                    
+                }
             }
         }
     }
@@ -332,6 +332,7 @@ public class Character : FSMController<CharacterState, CharacterFSM, CharacterDa
         targetMark.GetComponent<SpriteRenderer>().sprite = await ResourceManager.instance.LoadAsset<Sprite>("Role_" + userInfo.roleType.ToString(), eAddressableType.Thumbnail);
         minimapIcon.gameObject.SetActive(false);
         ChangeState<CharacterDeathState>();
+        GameManager.instance.CheckBossRound(userInfo);
     }
 
     protected override T ChangeState<T>()


### PR DESCRIPTION
보스라운드 관련 변수추가
보스라운드에 생존자 전멸 시 게임종료 리퀘스트 보내는 메소드 추가 ( Character의 SetDeath 시 호출) fix Character.cs
SetDeath 시 보스라운드 체크 메소드 호출
fix PopupResult.prefab
결과창 표시 캐릭터 3개 -> 4개로 수정